### PR TITLE
feat: add 'set_seed' function and test script for model prediction

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from tqdm import tqdm
+
+import torch
+import torch.nn.functional as F
+
+from data_loader.data_loaders import data_loader
+
+
+def inference(model, test_loader):
+    model = torch.load("checkpoints/model.pt")
+    model.to(device)
+
+    preds = []
+    with torch.no_grad():
+        model.eval()
+        for batch_in, _ in tqdm(test_loader):
+            batch_in = batch_in.to(device)
+            y_pred = model(batch_in)
+            y_pred = torch.argmax(y_pred, 1)
+            preds.extend(y_pred.cpu().numpy())
+
+    submit = pd.read_csv("data/sample_submission.csv")
+    submit["Label"] = preds
+    submit.to_csv("predicts/predict.csv", index=False)
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torch.load("checkpoints/model.pt")
+    model.to(device)
+    inference(model, data_loader("test", batch_size=1024))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,14 @@
+import numpy as np
+import random
+
+import torch
+
+
+def set_seed(seed):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    np.random.seed(seed)
+    random.seed(seed)


### PR DESCRIPTION
## 변경 사항 요약
이 PR은 모델 예측을 위한 추론 기능과 스크립트를 추가

## 상세 설명
### 커밋 1: feat: add function to set random seed for reproducibility
- Added `set_seed` function to ensure reproducibility by setting seeds for torch, numpy, and random.

### 커밋 2: feat: add inference script for model prediction
- Implemented `inference` function to perform model predictions on test data.
- Saved predictions to `predicts/predict.csv` using a template from `data/sample_submission.csv`.
