### PR TITLE
feat: add inference script for model prediction

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from tqdm import tqdm
+
+import torch
+import torch.nn.functional as F
+
+from data_loader.data_loaders import data_loader
+
+
+def inference(model, test_loader):
+    model = torch.load("checkpoints/model.pt")
+    model.to(device)
+
+    preds = []
+    with torch.no_grad():
+        model.eval()
+        for batch_in, _ in tqdm(test_loader):
+            batch_in = batch_in.to(device)
+            y_pred = model(batch_in)
+            y_pred = torch.argmax(y_pred, 1)
+            preds.extend(y_pred.cpu().numpy())
+
+    submit = pd.read_csv("data/sample_submission.csv")
+    submit["Label"] = preds
+    submit.to_csv("predicts/predict.csv", index=False)
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = torch.load("checkpoints/model.pt")
+    model.to(device)
+    inference(model, data_loader("test", batch_size=1024))


### PR DESCRIPTION
### feat: add inference script for model prediction
 - `inference` 함수를 구현하여 `test.py`에 추가
 - 테스트 데이터에 대한 모델 예측을 수행하고 `tqdm`을 사용하여 추론 과정의 진행 상황을 추적
 - 예측 결과를 `data/sample_submission.csv` 템플릿을 사용하여 `predicts/predict.csv`에 저장
